### PR TITLE
Don't echo messages (Skype bug)

### DIFF
--- a/lib/handlers/skype.js
+++ b/lib/handlers/skype.js
@@ -16,6 +16,7 @@ const Skype = function Skype() {
       && message.resource.messagetype !== 'Control/Typing'
       && message.resource.messagetype !== 'Control/ClearTyping') {
         const sender = message.resource.from.match(/8\:(.+)/gi)[1] || message.resource.imdisplayname
+        if (sender == config.skype.username) return; //Message from self. Ignore.
         const content = unescape(strip(message.resource.content))
         const handler = 'skype'
 


### PR DESCRIPTION
If the Skype login ID was different then the Skype username it would echo the message (making it appear twice) 

This Fixes that.